### PR TITLE
Fix handling escaped strings

### DIFF
--- a/Example/Tests/Tests/ZSWStringParserSpec.m
+++ b/Example/Tests/Tests/ZSWStringParserSpec.m
@@ -148,6 +148,37 @@ describe(@"ZSWStringParser", ^{
         
         expect(tag.tagAttributes).to.equal(@{@"type": @"lol"});
     });
+    
+    it(@"should handle a string containing an escaped string", ^{
+        ZSWTaggedString *taggedString = [ZSWTaggedString stringWithFormat:@"i like to eat <eat>%@</eat>", ZSWEscapedStringForString(@"<apples>")];
+        
+        NSArray *tags;
+        [[mockOptions expect] updateAttributedString:OCMOCK_ANY
+                                     updatedWithTags:[OCMArg capture:&tags]];
+        
+        expect([[ZSWStringParser stringWithTaggedString:taggedString
+                                                options:mockOptions
+                                            returnClass:[NSAttributedString class]] string]).to.equal(@"i like to eat <apples>");
+        expect(tags).to.haveCountOf(1);
+        
+        ZSWStringParserTag *tag = tags.firstObject;
+        expect(tag.tagName).to.equal(@"eat");
+        expect(tag.tagRange.location).to.equal(14);
+        expect(tag.tagRange.length).to.equal(8);
+    });
+    
+    it(@"should handle a string containing an escaped string at the very end", ^{
+        ZSWTaggedString *taggedString = [ZSWTaggedString stringWithFormat:@"i like to eat %@", ZSWEscapedStringForString(@"<")];
+        
+        NSArray *tags;
+        [[mockOptions expect] updateAttributedString:OCMOCK_ANY
+                                     updatedWithTags:[OCMArg capture:&tags]];
+        
+        expect([[ZSWStringParser stringWithTaggedString:taggedString
+                                                options:mockOptions
+                                            returnClass:[NSAttributedString class]] string]).to.equal(@"i like to eat <");
+        expect(tags).to.haveCountOf(0);
+    });
 });
 
 SpecEnd

--- a/ZSWTaggedString/Private/ZSWStringParser.m
+++ b/ZSWTaggedString/Private/ZSWStringParser.m
@@ -68,8 +68,9 @@ extern NSString *ZSWEscapedStringForString(NSString *unescapedString) {
         [scanner scanCharactersFromSet:tagStartCharacterSet intoString:NULL];
         
         if ([scratchString characterAtIndex:(scratchString.length - 1)] == kTagIgnore) {
-            // We found a tag start, but it's one that's been escaped. Skip it.
+            // We found a tag start, but it's one that's been escaped. Skip it, and append the start tag we just gobbled up.
             [pendingString deleteCharactersInRange:NSMakeRange(pendingString.length - 1, 1)];
+            [self appendString:kTagStart intoAttributedString:pendingString];
             continue;
         }
         


### PR DESCRIPTION
Adds tests and corrects issue with escaped strings missing their start `<` when evaluated.
